### PR TITLE
Add an event that is thrown when an article is updated or inserted

### DIFF
--- a/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
@@ -101,6 +101,10 @@ class ArticleWriter
         $this->validator->validate($article, ArticleDataType::$mapper);
         $article = $this->dataManager->setArticleData($article, ArticleDataType::$articleFieldsMapping);
 
+        Shopware()->Events()->notify('Shopware_Plugins_SwagImportExport_UpdateArticle', new \Enlight_Event_EventArgs(array(
+            'article' => $article
+        )));
+
         // insert/update article
         $builder = $this->dbalHelper->getQueryBuilderForEntity(
             $article,


### PR DESCRIPTION
For the stock handling in Pickware we need to keep track of the `inStock` value of articles. At the moment, we do not have the opportunity to react to `inStock` changes performed via the new Import/Export module. Since the SwagImportExport plugin uses DBAL, we also cannot use Doctrine events for this purpose. For this reason, we would like to have a notify event that we can subscribe to, that contains the article data when a new article is created or an existing article is updated via an import.