### PR TITLE
Add missing import for custom DbAdapters.

### DIFF
--- a/Components/SwagImportExport/Factories/DataFactory.php
+++ b/Components/SwagImportExport/Factories/DataFactory.php
@@ -3,6 +3,7 @@
 namespace Shopware\Components\SwagImportExport\Factories;
 
 use Shopware\Components\SwagImportExport\DataIO;
+use Shopware\Components\SwagImportExport\DbAdapters\DataDbAdapter;
 use Shopware\Components\SwagImportExport\Session\Session;
 use Shopware\Components\SwagImportExport\Logger\Logger;
 use Shopware\Components\SwagImportExport\Utils\DataColumnOptions;


### PR DESCRIPTION
The `instanceof` check for custom `DbAdapter`s via `Shopware_Components_SwagImportExport_Factories_CreateDbAdapter` is always failing as the import for `DataDbAdapter` is currently missing. This PR fixes the issue by adding the import.