### PR TITLE
Fix a PHP Strict Warning

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -763,7 +763,9 @@ final class Shopware_Plugins_Backend_SwagImportExport_Bootstrap extends Shopware
         $schema = $tool->getSchemaFromMetadata($classes);
         $tableNames = [];
         foreach ($schema->getTableNames() as $tableName) {
-            $tableNames[] = array_pop(explode('.', $tableName));
+            
+            $tableNamesArray = explode('.', $tableName)
+            $tableNames[] = array_pop($tableNamesArray);
         }
         return $tableNames;
     }


### PR DESCRIPTION
"PHP Strict Standards:  Only variables should be passed by reference" fixed in bootstrap.php