### PR TITLE
Fix CSVFileReader line break detection

### DIFF
--- a/Components/SwagImportExport/FileIO/CsvFileReader.php
+++ b/Components/SwagImportExport/FileIO/CsvFileReader.php
@@ -41,6 +41,9 @@ class CsvFileReader implements FileReader
      */
     public function readRecords($fileName, $position, $step)
     {
+        // Make sure to detect CR LF (Windows) line breaks
+        ini_set('auto_detect_line_endings', true);
+
         $tempFileName = '';
         if (file_exists($fileName)) {
             $tempFileName = $this->uploadPathProvider->getRealPath(md5(microtime() . '.csv'));


### PR DESCRIPTION
When trying to import a CSV file that was created on Windows and therefore uses CR LF (“carriage return line feed” `\r\n`) as line breaks, `SplFileObject` cannot detect the line breaks correctly, if PHP’s `auto_detect_line_endings` is disabled. As a result, the whole CSV files is parsed as a single line, which e.g. breaks the field validation because the header line is checked.

This PR fixes the line break detection by temporarily enabling `auto_detect_line_endings` when reading the records upon import.