### PR TITLE
Update .sw-zip-blacklist

### DIFF
--- a/.sw-zip-blacklist
+++ b/.sw-zip-blacklist
@@ -1,1 +1,2 @@
 psh.phar
+.DS_Store


### PR DESCRIPTION
Add Mac OS X' Desktop Services Store file to the blacklist. This file is usually in any folder which has been opened with Finder