### PR TITLE
Feature/fix categoryimport

### DIFF
--- a/Components/SwagImportExport/DbAdapters/Articles/CategoryWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/CategoryWriter.php
@@ -263,12 +263,12 @@ class CategoryWriter
      */
     protected function isLeaf($categoryId)
     {
-        $isLeaf = $this->db->fetchOne(
+        $isParent = $this->db->fetchOne(
             "SELECT id FROM s_categories WHERE parent = ?",
             [$categoryId]
         );
 
-        return is_numeric($isLeaf);
+        return $isParent === false;
     }
 
     /**

--- a/Components/SwagImportExport/DbAdapters/Articles/CategoryWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/CategoryWriter.php
@@ -215,12 +215,12 @@ class CategoryWriter
     {
         if ($id === null) {
             $this->isRootExists();
-            $values = "(1, NULL, NOW(), NOW(), '{$description}', 1)";
+            $values = "(1, NULL, NOW(), NOW(), '{$description}', 1, 0, 0, 0, 0, 0, 0)";
         } else {
-            $values = "({$id}, '{$path}', NOW(), NOW(), '{$description}', 1)";
+            $values = "({$id}, '{$path}', NOW(), NOW(), '{$description}', 1, 0, 0, 0, 0, 0, 0)";
         }
 
-        $sql = "INSERT INTO s_categories (parent, path, added, changed, description, active)
+        $sql = "INSERT INTO s_categories (`parent`, `path`, `added`, `changed`, `description`, `active`, `left`, `right`, `level`, `blog`, `hidefilter`, `hidetop`)
                 VALUES {$values}";
 
         $this->db->exec($sql);


### PR DESCRIPTION
If you create an profile based on any default article profile and change the category database mapping from id to path the import fails while creating new categories. This PR fixes that issue.

How to test:
- create a new article import/export profile based on any default_article profile
- change the categories database mapping from categoryId to categoryPath
- Export an article and change the category path in the export file to end with a non existing category
- Import that changed file

Without this fix the import fails with an "Category X is not a leaf" error, the new category is not created. With this fix the new category will be correctly created and assigned to the article.