### PR TITLE
Support column with _<Number>

### DIFF
--- a/Components/SwagImportExport/DbAdapters/ArticlesDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/ArticlesDbAdapter.php
@@ -1556,7 +1556,21 @@ class ArticlesDbAdapter implements DataDbAdapter
      */
     private function underscoreToCamelCase($underscoreString)
     {
-        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $underscoreString))));
+        $underscoreData = explode('_', $underscoreString);
+        $lastElement = array_pop($underscoreData);
+        $isLastElmNum = is_numeric($lastElement);
+
+        if($isLastElmNum) {
+            $underscoreString = implode('_', $underscoreData);
+        }
+
+        $camelCaseString = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $underscoreString))));
+
+        if($isLastElmNum) {
+            $camelCaseString .= '_' . $lastElement;
+        }
+
+        return $camelCaseString;
     }
 
     /**


### PR DESCRIPTION
The method "underscoreToCamelCase" must be extended to support column with _<Number>. Otherwise you will get an error, if you try to export articles with attributes e.g. "download_file_1".

Doctrine does expect "downloadFile_1" and not "downloadFile1".