### PR TITLE
underscoreToCamelCase Missmatch

### DIFF
--- a/Components/SwagImportExport/DbAdapters/ArticlesDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/ArticlesDbAdapter.php
@@ -1556,7 +1556,11 @@ class ArticlesDbAdapter implements DataDbAdapter
      */
     private function underscoreToCamelCase($underscoreString)
     {
-        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $underscoreString))));
+        $func = function ($c) {
+            return strtoupper($c[1]);
+        };
+
+        return lcfirst(preg_replace_callback('/_([a-zA-Z])/', $func, $underscoreString));
     }
 
     /**


### PR DESCRIPTION
Different underscoreToCamelCase in Shopware\Components\Model\Generator and here. Resulting in error when attributes containing Numbers.

foo_10_bar
Shopware\Components\Model\Generator: foo_10Bar
Shopware\Components\SwagImportExport\DbAdapters\ArticlesDbAdapter: foo10Bar

Probably the same problem in the other DbAdapters as well.