### PR TITLE
New mode for overwriting existing media images

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -641,7 +641,8 @@ final class Shopware_Plugins_Backend_SwagImportExport_Bootstrap extends Shopware
                 'label' => 'Image import mode',
                 'store' => [
                     [1, ['de_DE' => 'Gleiche Artikelbilder erneut verwenden', 'en_GB' => 'Re-use same article images']],
-                    [2, ['de_DE' => 'Gleiche Artikelbilder nicht erneut verwenden', 'en_GB' => 'Don\'t re-use article images']]
+                    [2, ['de_DE' => 'Gleiche Artikelbilder nicht erneut verwenden', 'en_GB' => 'Don\'t re-use article images']],
+                    [3, ['de_DE' => 'Gleiche Artikelbilder überschreiben', 'en_GB' => 'Overwrite existing article images']],
                 ],
                 'required' => false,
                 'multiSelect' => false,

--- a/Components/SwagImportExport/DbAdapters/ArticlesImagesDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/ArticlesImagesDbAdapter.php
@@ -290,6 +290,18 @@ class ArticlesImagesDbAdapter implements DataDbAdapter
                     $media = $mediaRepository->findOneBy(['name' => $name]);
                 }
 
+                // overwrite existing media
+                if ($this->imageImportMode === 3) {
+                    $mediaRepository = $this->manager->getRepository(Media::class);
+                    $media = $mediaRepository->findOneBy(['name' => $name]);
+
+                    if ($media) {
+                        $this->manager->remove($media);
+                        $this->manager->flush();
+                        $media = false;
+                    }
+                }
+
                 //create new media
                 if ($this->imageImportMode === 2 || empty($media)) {
                     $path = $this->load($record['image'], $name);


### PR DESCRIPTION
Adds another SwagImportExportImageMode mode to overwrite existing images. Thus you don't need to delete manually a media file prior to its import if the name is the same but the file is different.