### PR TITLE
Respect config option for decimal separator when exporting article prices

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -567,7 +567,7 @@ final class Shopware_Plugins_Backend_SwagImportExport_Bootstrap extends Shopware
             'useCommaDecimal',
             [
                 'label' => 'Use comma as decimal separator',
-                'value' => false,
+                'value' => true,
             ]
         );
 

--- a/Components/SwagImportExport/DbAdapters/ArticlesPricesDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/ArticlesPricesDbAdapter.php
@@ -116,15 +116,15 @@ class ArticlesPricesDbAdapter implements DataDbAdapter
         // add the tax if needed
         foreach ($result['default'] as &$record) {
             if ($record['taxInput']) {
-                $record['price'] = str_replace('.', ',', round($record['price'] * (100 + $record['tax']) / 100, 2));
-                $record['pseudoPrice'] = str_replace('.', ',', round($record['pseudoPrice'] * (100 + $record['tax']) / 100, 2));
+                $record['price'] = round($record['price'] * (100 + $record['tax']) / 100, 2);
+                $record['pseudoPrice'] = round($record['pseudoPrice'] * (100 + $record['tax']) / 100, 2);
             } else {
-                $record['price'] = str_replace('.', ',', round($record['price'], 2));
-                $record['pseudoPrice'] = str_replace('.', ',', round($record['pseudoPrice'], 2));
+                $record['price'] = round($record['price'], 2);
+                $record['pseudoPrice'] = round($record['pseudoPrice'], 2);
             }
 
             if ($record['purchasePrice']) {
-                $record['purchasePrice'] = str_replace('.', ',', round($record['purchasePrice'], 2));
+                $record['purchasePrice'] = round($record['purchasePrice'], 2);
             }
         }
 

--- a/Tests/Functional/Controllers/Backend/SwagImportExport/ArticlePricesExportTest.php
+++ b/Tests/Functional/Controllers/Backend/SwagImportExport/ArticlePricesExportTest.php
@@ -46,7 +46,7 @@ class ArticlePricesExportTest extends \Enlight_Components_Test_Controller_TestCa
         $this->assertFileExists($file, "File not found {$fileName}");
         $this->backendControllerTestHelper->addFile($file);
 
-        $this->assertPriceAttributeInXml($file, 'SW10002.1', 'price', '59,99');
+        $this->assertPriceAttributeInXml($file, 'SW10002.1', 'price', '59.99');
         $this->assertPriceAttributeInXml($file, 'SW10002.1', '_name', 'Münsterländer Lagerkorn 32%');
         $this->assertPriceAttributeInXml($file, 'SW10002.1', '_additionaltext', '1,5 Liter');
     }
@@ -68,7 +68,7 @@ class ArticlePricesExportTest extends \Enlight_Components_Test_Controller_TestCa
         $this->backendControllerTestHelper->addFile($file);
 
         $mappedPriceList = $this->csvToArrayIndexedByFieldValue($file, 'ordernumber');
-        $this->assertEquals('59,99', $mappedPriceList['SW10002.1']['price']);
+        $this->assertEquals('59.99', $mappedPriceList['SW10002.1']['price']);
         $this->assertEquals('Münsterländer Lagerkorn 32%', $mappedPriceList['SW10002.1']['_name']);
         $this->assertEquals('1,5 Liter', $mappedPriceList['SW10002.1']['_additionaltext']);
     }

--- a/Tests/Shopware/ImportExport/TestCases/articlePricesDbAdapter.yml
+++ b/Tests/Shopware/ImportExport/TestCases/articlePricesDbAdapter.yml
@@ -4,17 +4,17 @@ testRead:
         ids: [3, 4, 6, 20, 21, 22]
         expected:
             0:
-                price: '14,95'
+                price: 14.95
             1:
-                price: '7,99'
+                price: 7.99
             2:
-                price: '35,95'
+                price: 35.95
             3:
-                price: '49,95'
+                price: 49.95
             4:
-                price: '24,99'
+                price: 24.99
             5:
-                price: '5,95'
+                price: 5.95
         expectedCount: 6
 testReadRecordIds:
     test1:

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -44,6 +44,11 @@ class ImportExportTestKernel extends TestKernel
         Shopware()->Loader()->registerNamespace('Shopware\CustomModels', __DIR__ . '/../Models/');
 
         self::registerResources();
+
+        Shopware()->Db()->query(
+            'UPDATE s_core_config_elements SET value = \'b:0;\' WHERE name = \'useCommaDecimal\''
+        );
+        Shopware()->Container()->get('cache')->clean();
     }
 
     /**


### PR DESCRIPTION
**Problem:**
The config option whether to use commas or dots as decimal separators is not respected when exporting article prices.
This is because the conversion is hardcoded in the repective db adapter.

Actually the conversion is already done automatically respecively to the config option.

**Solution**
This PR removes the hardcoded conversion to conversion is now done as expected and as set in the plugin config.

**Addition**
This PR sets the default value of the config element `useCommaDecimal` to `true`. This is done because the most users use Microsoft Excel so open edit exported .csv files. Also most users of Shopware are German. And a dot as separator does not work with a German Microsoft Excel. So the config value is changed to a more userfriendly default.