### PR TITLE
Fix order export if order detail `taxID` is null

### DIFF
--- a/Components/SwagImportExport/DbAdapters/MainOrdersDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/MainOrdersDbAdapter.php
@@ -483,13 +483,14 @@ class MainOrdersDbAdapter implements DataDbAdapter
      */
     private function calculateTaxSum($taxData)
     {
-        if (empty($taxData['taxRate'])) {
+        $taxValue = 0;
+        if (!empty($taxData['taxRate'])) {
+            $taxValue = $taxData['taxRate'];
+        } elseif ($taxData['taxId'] !== null) {
             $taxModel = $this->modelManager->getRepository(Tax::class)->find($taxData['taxId']);
             if ($taxModel && $taxModel->getId() !== 0 && $taxModel->getId() !== null && $taxModel->getTax() !== null) {
                 $taxValue = $taxModel->getTax();
             }
-        } else {
-            $taxValue = $taxData['taxRate'];
         }
 
         $price = $taxData['price'] * $taxData['quantity'];


### PR DESCRIPTION
When exporting an order that contains an item whose `taxID` is `null` and `tax_rate` is zero, the export fails due to an exception, because the DB adapter tries to find a tax rate using `null` as query parameter. Orders created using the Shopware checkout for some reason [set `0` instead `null` for the `taxID`, if no tax is mapped](https://github.com/shopware/shopware/blob/b16d584b54d8edd2724bfedf5a6cc86580afe3c9/engine/Shopware/Core/sOrder.php#L486-L488), and hence never trigger this error. Based on the database schema of `s_order_details` it is fine though to set `taxID` to `null`.

This PR adds an extra check to `MainOrdersDbAdapter::calculateTaxSum()` to prevent using `null` for querying tax entities and fall back to using `0` as the tax rate instead.

I also added a new test for that scenario and verified that all other tests still pass as well.