### PR TITLE
Fix loading of plugin namespaces

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -396,6 +396,17 @@ final class Shopware_Plugins_Backend_SwagImportExport_Bootstrap extends Shopware
     }
 
     /**
+     * This event needs to be registered so it's guaranteed this plugin's afterInit() method will always be called and
+     * gets a chance to register the plugin's namespaces.
+     *
+     * @param \Enlight_Event_EventArgs $args
+     */
+    public function onStartDispatch(Enlight_Event_EventArgs $args)
+    {
+        // Nothing to do
+    }
+
+    /**
      * @return UploadPathProvider
      */
     public function registerUploadPathProvider()
@@ -623,6 +634,11 @@ final class Shopware_Plugins_Backend_SwagImportExport_Bootstrap extends Shopware
      */
     protected function registerEvents()
     {
+        $this->subscribeEvent(
+            'Enlight_Controller_Front_StartDispatch',
+            'onStartDispatch'
+        );
+
         $this->subscribeEvent(
             'Enlight_Bootstrap_InitResource_swag_import_export.csv_file_writer',
             'registerCsvFileWriter'


### PR DESCRIPTION
At the moment, SwagImportExport subscribes to:

- `Shopware_Console_Add_Command`,
- `Enlight_Controller_Action_PostDispatch_Backend_Index`,
- `Shopware_CronJob_CronAutoImport`,
- and a bunch of `InitResource` events to register its services.

Because of this, it's not guaranteed that the plugin's `afterInit()` method registering its namespaces will be called on every request. In particular, the plugin's namespaces are not registered when the `update()` method of dependent plugins (such as "Shopware ERP powered by Pickware") is executed. 

This has just caused a critical installation issue for us. We've been able to deploy a workaround, but I believe any plugin's namespaces should _always_ be registered, not just during requests which are relevant for that plugin. This PR accomplishes this for SwagImportExport by adding a no-op subscriber to `Enlight_Controller_Front_StartDispatch`.