### PR TITLE
prevent memory exhaustion on downloading large files

### DIFF
--- a/Controllers/Backend/SwagImportExport.php
+++ b/Controllers/Backend/SwagImportExport.php
@@ -117,7 +117,7 @@ class Shopware_Controllers_Backend_SwagImportExport extends Shopware_Controllers
             $response->setHeader('Content-Type', $application);
             $response->sendHeaders();
 
-            echo file_get_contents($filePath);
+            readfile($filePath);
             exit();
         } catch (\Exception $e) {
             $this->View()->assign(


### PR DESCRIPTION
file_get_contents() loads the whole file into memory before echoing it. This may lead to memory exhaustion, when downloading large files. Since, the file content is not altered at all while processing it, it could be streamed to the output buffer directly.