### PR TITLE
Allowing 0 for non-default prices

### DIFF
--- a/Components/SwagImportExport/DbAdapters/Articles/PriceWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/PriceWriter.php
@@ -76,8 +76,8 @@ class PriceWriter
 
             $this->checkRequirements($price, $orderNumber);
 
-            // skip empty prices for non-default customer groups
-            if (empty($price['price']) && $price['priceGroup'] !== 'EK') {
+            // skip empty strings for non-default customer group prices
+            if ($price['price'] === '' && $price['priceGroup'] !== 'EK') {
                 continue;
             }
 


### PR DESCRIPTION
We need to import 0 prices for certain customergroups, so i modified the condition to allow such cases.
Otherwise we had to manipulate every price for these groups manually, to avoid loading default prices.
Since the import reads a textfile, the $price['price'] value should never be NULL or false, so it should suffice to test for empty string.