### PR TITLE
Used root directory to support composer installations

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -438,7 +438,8 @@ final class Shopware_Plugins_Backend_SwagImportExport_Bootstrap extends Shopware
     {
         return new Logger(
             $this->get('swag_import_export.csv_file_writer'),
-            $this->get('models')
+            $this->get('models'),
+            $this->Application()->Container()->getParameter('shopware.app.rootdir') . 'var/log'
         );
     }
 

--- a/Components/SwagImportExport/Logger/Logger.php
+++ b/Components/SwagImportExport/Logger/Logger.php
@@ -37,13 +37,20 @@ class Logger implements LoggerInterface
     protected $fileWriter;
 
     /**
+     * @var string
+     */
+    protected $logDirectory;
+
+    /**
      * @param FileWriter   $fileWriter
      * @param ModelManager $modelManager
+     * @param string       $logDirectory
      */
-    public function __construct(FileWriter $fileWriter, ModelManager $modelManager)
+    public function __construct(FileWriter $fileWriter, ModelManager $modelManager, $logDirectory)
     {
         $this->fileWriter = $fileWriter;
         $this->modelManager = $modelManager;
+        $this->logDirectory = $logDirectory;
         $this->loggerRepository = $this->modelManager->getRepository(LoggerEntity::class);
     }
 
@@ -92,7 +99,7 @@ class Logger implements LoggerInterface
      */
     private function getLogFile()
     {
-        $filePath = Shopware()->DocPath() . 'var/log/importexport.log';
+        $filePath = $this->logDirectory . '/importexport.log';
 
         if (!file_exists($filePath)) {
             $this->createLogFile($filePath);


### PR DESCRIPTION
In my composer installation the log files were put into `vendor/shopware/shopware/var/log` was not that easy to find.