### PR TITLE
Update DataWorkflow.php - If $outputFile is empty

### DIFF
--- a/Components/SwagImportExport/DataWorkflow.php
+++ b/Components/SwagImportExport/DataWorkflow.php
@@ -211,7 +211,7 @@ class DataWorkflow
      */
     public function saveUnprocessedData($postData, $profileName, $outputFile)
     {
-        if ($postData['session']['prevState'] === 'new') {
+        if ($postData['session']['prevState'] === 'new'  || !filesize($outputFile)) {
             $header = $this->transformerChain->composeHeader();
             $this->fileIO->writeHeader($outputFile, $header);
         }


### PR DESCRIPTION
If "saveUnprocessedData" is called from the second pass of "ImportService", "prevState" is not "new".

Then the "*-articlesImages-swag.csv" has no Header an fails.