### PR TITLE
Allow "kind" to be imported

### DIFF
--- a/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
@@ -125,6 +125,23 @@ class ArticleWriter
         $article['articleId'] = $articleId;
         if (!isset($article['kind']) || empty($article['kind'])) {
             $article['kind'] = $mainDetailId == $detailId ? 1 : 2;
+        } else {
+            $this->db->query('
+            UPDATE
+                s_articles a
+                LEFT JOIN s_articles_details d ON d.id = a.main_detail_id
+            SET
+                a.main_detail_id = (
+                    SELECT
+                        id
+                    FROM
+                        s_articles_details
+                    WHERE
+                        articleID = a.id
+                        AND kind = 1
+                    LIMIT 1)
+            WHERE a.id = ?
+            ', [$articleId]);
         }
         list($article, $detailId) = $this->createOrUpdateArticleDetail($article, $defaultValues, $detailId, $createDetail);
 

--- a/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
@@ -123,7 +123,9 @@ class ArticleWriter
         }
 
         $article['articleId'] = $articleId;
-        $article['kind'] = $mainDetailId == $detailId ? 1 : 2;
+        if (!isset($article['kind']) || empty($article['kind'])) {
+            $article['kind'] = $mainDetailId == $detailId ? 1 : 2;
+        }
         list($article, $detailId) = $this->createOrUpdateArticleDetail($article, $defaultValues, $detailId, $createDetail);
 
         // set reference


### PR DESCRIPTION
Currently the ArticleWriter blindly overrules any kind field that might be imported.
This change checks, if the "kind" field is already filled in and leaves it alone if it's already present