### PR TITLE
Prepare DbAdapters to be used via DI

### DIFF
--- a/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/ArticleWriter.php
@@ -9,6 +9,7 @@
 namespace Shopware\Components\SwagImportExport\DbAdapters\Articles;
 
 use Doctrine\DBAL\Connection;
+use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Shopware\Components\SwagImportExport\DataManagers\Articles\ArticleDataManager;
 use Shopware\Components\SwagImportExport\DataType\ArticleDataType;
 use Shopware\Components\SwagImportExport\DbAdapters\Results\ArticleWriterResult;
@@ -23,7 +24,7 @@ use Shopware\Models\Attribute\Article as ProductAttribute;
 class ArticleWriter
 {
     /**
-     * @var \Enlight_Components_Db_Adapter_Pdo_Mysql
+     * @var Enlight_Components_Db_Adapter_Pdo_Mysql
      */
     protected $db;
 
@@ -46,18 +47,30 @@ class ArticleWriter
      * @var DbalHelper
      */
     private $dbalHelper;
+    /**
+     * @var ArticleValidator
+     */
+    private $articleValidator;
+    /**
+     * @var ArticleDataManager
+     */
+    private $articleDataManager;
 
     /**
      * initialises the class properties
+     * @param Connection $connection
+     * @param Enlight_Components_Db_Adapter_Pdo_Mysql $db
+     * @param DbalHelper $dbalHelper
+     * @param ArticleValidator $articleValidator
+     * @param ArticleDataManager $articleDataManager
      */
-    public function __construct()
+    public function __construct(Connection $connection, Enlight_Components_Db_Adapter_Pdo_Mysql $db, DbalHelper $dbalHelper, ArticleValidator $articleValidator, ArticleDataManager $articleDataManager)
     {
-        $this->connection = Shopware()->Container()->get('dbal_connection');
-        $this->db = Shopware()->Container()->get('db');
-        $this->dbalHelper = DbalHelper::create();
-
-        $this->validator = new ArticleValidator();
-        $this->dataManager = new ArticleDataManager($this->db, $this->dbalHelper);
+        $this->connection = $connection;
+        $this->db = $db;
+        $this->dbalHelper = $dbalHelper;
+        $this->articleValidator = $articleValidator;
+        $this->articleDataManager = $articleDataManager;
     }
 
     /**

--- a/Components/SwagImportExport/DbAdapters/Articles/CategoryWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/CategoryWriter.php
@@ -10,7 +10,7 @@ namespace Shopware\Components\SwagImportExport\DbAdapters\Articles;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
-use Enlight_Components_Db_Adapter_Pdo_Mysql as PDOConnection;
+use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Enlight_Event_EventManager as EventManager;
 use Shopware\Components\Model\CategorySubscriber;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
@@ -19,7 +19,7 @@ use Shopware\Components\SwagImportExport\Utils\SnippetsHelper;
 class CategoryWriter
 {
     /**
-     * @var PDOConnection
+     * @var Enlight_Components_Db_Adapter_Pdo_Mysql
      */
     protected $db;
 
@@ -37,15 +37,22 @@ class CategoryWriter
      * @var EventManager
      */
     private $eventManager;
+    /**
+     * @var EventManager
+     */
+    private $events;
 
     /**
      * initialises the class properties
+     * @param Enlight_Components_Db_Adapter_Pdo_Mysql $db
+     * @param Connection $connection
+     * @param EventManager $events
      */
-    public function __construct()
+    public function __construct(Enlight_Components_Db_Adapter_Pdo_Mysql $db, Connection $connection, EventManager $events)
     {
-        $this->db = Shopware()->Db();
-        $this->connection = Shopware()->Models()->getConnection();
-        $this->eventManager = Shopware()->Events();
+        $this->db = $db;
+        $this->connection = $connection;
+        $this->events = $events;
     }
 
     /**

--- a/Components/SwagImportExport/DbAdapters/Articles/ImageWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/ImageWriter.php
@@ -9,7 +9,7 @@
 namespace Shopware\Components\SwagImportExport\DbAdapters\Articles;
 
 use Doctrine\DBAL\Connection;
-use Enlight_Components_Db_Adapter_Pdo_Mysql as PDOConnection;
+use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Shopware\Components\SwagImportExport\DbAdapters\ArticlesDbAdapter;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
 use Shopware\Components\SwagImportExport\Utils\SnippetsHelper;
@@ -22,7 +22,7 @@ class ImageWriter
     protected $articlesDbAdapter;
 
     /**
-     * @var PDOConnection
+     * @var Enlight_Components_Db_Adapter_Pdo_Mysql
      */
     protected $db;
 
@@ -31,11 +31,11 @@ class ImageWriter
      */
     protected $connection;
 
-    public function __construct(ArticlesDbAdapter $articlesDbAdapter)
+    public function __construct(ArticlesDbAdapter $articlesDbAdapter, Enlight_Components_Db_Adapter_Pdo_Mysql $db, Connection $connection)
     {
         $this->articlesDbAdapter = $articlesDbAdapter;
-        $this->db = Shopware()->Db();
-        $this->connection = Shopware()->Models()->getConnection();
+        $this->db = $db;
+        $this->connection = $connection;
     }
 
     /**

--- a/Components/SwagImportExport/DbAdapters/Articles/PriceWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/PriceWriter.php
@@ -8,7 +8,7 @@
 
 namespace Shopware\Components\SwagImportExport\DbAdapters\Articles;
 
-use Enlight_Components_Db_Adapter_Pdo_Mysql as PDOConnection;
+use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Shopware\Components\SwagImportExport\DataManagers\Articles\PriceDataManager;
 use Shopware\Components\SwagImportExport\DbalHelper;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
@@ -19,7 +19,7 @@ use Shopware\Models\Article\Price;
 class PriceWriter
 {
     /**
-     * @var PDOConnection
+     * @var Enlight_Components_Db_Adapter_Pdo_Mysql
      */
     protected $db;
 
@@ -42,16 +42,28 @@ class PriceWriter
      * @var DbalHelper
      */
     private $dbalHelper;
+    /**
+     * @var PriceValidator
+     */
+    private $priceValidator;
+    /**
+     * @var PriceDataManager
+     */
+    private $priceDataManager;
 
     /**
      * initialises the class properties
+     * @param Enlight_Components_Db_Adapter_Pdo_Mysql $db
+     * @param DbalHelper $dbalHelper
+     * @param PriceValidator $priceValidator
+     * @param PriceDataManager $priceDataManager
      */
-    public function __construct()
+    public function __construct(Enlight_Components_Db_Adapter_Pdo_Mysql $db, DbalHelper $dbalHelper, PriceValidator $priceValidator, PriceDataManager $priceDataManager)
     {
-        $this->db = Shopware()->Db();
-        $this->dbalHelper = DbalHelper::create();
-        $this->validator = new PriceValidator();
-        $this->dataManager = new PriceDataManager();
+        $this->db = $db;
+        $this->dbalHelper = $dbalHelper;
+        $this->priceValidator = $priceValidator;
+        $this->priceDataManager = $priceDataManager;
 
         $this->customerGroups = $this->getCustomerGroup();
     }

--- a/Components/SwagImportExport/DbAdapters/Articles/RelationWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/RelationWriter.php
@@ -9,7 +9,7 @@
 namespace Shopware\Components\SwagImportExport\DbAdapters\Articles;
 
 use Doctrine\DBAL\Connection;
-use Enlight_Components_Db_Adapter_Pdo_Mysql as PDOConnection;
+use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Shopware\Components\SwagImportExport\DbAdapters\ArticlesDbAdapter;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
 use Shopware\Components\SwagImportExport\Utils\SnippetsHelper;
@@ -46,7 +46,7 @@ class RelationWriter
     protected $defaultSnippetMessage;
 
     /**
-     * @var PDOConnection
+     * @var Enlight_Components_Db_Adapter_Pdo_Mysql
      */
     protected $db;
 
@@ -55,11 +55,11 @@ class RelationWriter
      */
     protected $connection;
 
-    public function __construct(ArticlesDbAdapter $articlesDbAdapter)
+    public function __construct(ArticlesDbAdapter $articlesDbAdapter, Enlight_Components_Db_Adapter_Pdo_Mysql $db, Connection $connection)
     {
         $this->articlesDbAdapter = $articlesDbAdapter;
-        $this->db = Shopware()->Db();
-        $this->connection = Shopware()->Models()->getConnection();
+        $this->db = $db;
+        $this->connection = $connection;
     }
 
     /**

--- a/Components/SwagImportExport/DbAdapters/Articles/TranslationWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/TranslationWriter.php
@@ -13,7 +13,7 @@ use Shopware\Components\Model\ModelManager;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
 use Shopware\Components\SwagImportExport\Utils\SnippetsHelper;
 use Shopware\Models\Attribute\Configuration;
-use Shopware_Components_Translation as TranslationComponent;
+use Shopware_Components_Translation;
 
 class TranslationWriter
 {
@@ -28,7 +28,7 @@ class TranslationWriter
     private $connection;
 
     /**
-     * @var TranslationComponent
+     * @var Shopware_Components_Translation
      */
     private $writer;
 
@@ -40,11 +40,11 @@ class TranslationWriter
     /**
      * initialises the class properties
      */
-    public function __construct()
+    public function __construct(ModelManager $manager, Connection $connection, Shopware_Components_Translation $translation)
     {
-        $this->manager = Shopware()->Models();
-        $this->connection = $this->manager->getConnection();
-        $this->writer = Shopware()->Container()->get('translation');
+        $this->manager = $manager;
+        $this->connection = $connection;
+        $this->writer = $translation;
         $this->shops = $this->getShops();
     }
 

--- a/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/ArticleWriterTest.php
+++ b/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/ArticleWriterTest.php
@@ -10,8 +10,11 @@ namespace SwagImportExport\Tests\Functional\Components\SwagImportExport\DbAdapte
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Components\Model\ModelManager;
+use Shopware\Components\SwagImportExport\DataManagers\Articles\ArticleDataManager;
 use Shopware\Components\SwagImportExport\DbAdapters\Articles\ArticleWriter;
+use Shopware\Components\SwagImportExport\DbalHelper;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
+use Shopware\Components\SwagImportExport\Validators\Articles\ArticleValidator;
 use Shopware\Models\Article\Article;
 
 class ArticleWriterTest extends TestCase
@@ -29,10 +32,20 @@ class ArticleWriterTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->modelManager = Shopware()->Container()->get('models');
+        $container = Shopware()->Container();
+        $this->modelManager = $container->get('models');
         $this->modelManager->beginTransaction();
 
-        $this->articleWriter = new ArticleWriter();
+        $db = $container->get('db');
+        $dbalHelper = DbalHelper::create();
+
+        $this->articleWriter = new ArticleWriter(
+            $this->modelManager->getConnection(),
+            $db,
+            $dbalHelper,
+            new ArticleValidator(),
+            new ArticleDataManager($db, $dbalHelper)
+        );
     }
 
     protected function tearDown(): void

--- a/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/CategoryWriterTest.php
+++ b/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/CategoryWriterTest.php
@@ -75,6 +75,8 @@ class CategoryWriterTest extends TestCase
      */
     private function createCategoryWriterAdapter()
     {
-        return new CategoryWriter();
+        $container = Shopware()->Container();
+
+        return new CategoryWriter($container->get('dbal_connection'), $container->get('db'), $container->get('events'));
     }
 }

--- a/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/PriceWriterTest.php
+++ b/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/PriceWriterTest.php
@@ -10,7 +10,10 @@ namespace SwagImportExport\Tests\Functional\Components\SwagImportExport\DbAdapte
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Components\SwagImportExport\DataManagers\Articles\PriceDataManager;
 use Shopware\Components\SwagImportExport\DbAdapters\Articles\PriceWriter;
+use Shopware\Components\SwagImportExport\DbalHelper;
+use Shopware\Components\SwagImportExport\Validators\Articles\PriceValidator;
 use SwagImportExport\Tests\Helper\DatabaseTestCaseTrait;
 
 class PriceWriterTest extends TestCase
@@ -154,6 +157,8 @@ class PriceWriterTest extends TestCase
      */
     private function createPriceWriterAdapter()
     {
-        return new PriceWriter();
+        $container = Shopware()->Container();
+
+        return new PriceWriter($container->get('db'), DbalHelper::create(), new PriceValidator(), new PriceDataManager());
     }
 }

--- a/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/RelationWriterTest.php
+++ b/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/RelationWriterTest.php
@@ -22,10 +22,10 @@ class RelationWriterTest extends TestCase
      */
     public function createRelationWriterAdapter()
     {
-        //We need to get an instance of the ArticlesDbAdapter because of the given dependency
-        $articlesDbAdapter = new ArticlesDbAdapter();
+        $container = Shopware()->Container();
 
-        return new RelationWriter($articlesDbAdapter);
+        //We need to get an instance of the ArticlesDbAdapter because of the given dependency
+        return new RelationWriter(new ArticlesDbAdapter(), $container->get('db'), $container->get('dbal_connection'));
     }
 
     public function test_write_accessory_with_invalid_data_throws_exception()

--- a/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/TranslationWriterTest.php
+++ b/Tests/Functional/Components/SwagImportExport/DbAdapters/Articles/TranslationWriterTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Bundle\AttributeBundle\Service\CrudService;
 use Shopware\Components\SwagImportExport\DbAdapters\Articles\TranslationWriter;
 use Shopware\Components\SwagImportExport\Exception\AdapterException;
+use Shopware_Components_Translation;
 use SwagImportExport\Tests\Helper\DatabaseTestCaseTrait;
 
 class TranslationWriterTest extends TestCase
@@ -138,6 +139,8 @@ class TranslationWriterTest extends TestCase
      */
     private function createTranslationWriter()
     {
-        return new TranslationWriter();
+        $container = Shopware()->Container();
+
+        return new TranslationWriter($container->get('models'), $container->get('dbal_connection'), $container->get('translation'));
     }
 }


### PR DESCRIPTION
Remove global `Shopware()` calls and instead pass those variables directly into constructor. This is in preparation of another change that allows those DbAdapters to be valid symfony services, removing all construction details again.