### PR TITLE
make translatable field shippingTime importable and exportable

### DIFF
--- a/Components/SwagImportExport/DbAdapters/Articles/TranslationWriter.php
+++ b/Components/SwagImportExport/DbAdapters/Articles/TranslationWriter.php
@@ -64,11 +64,13 @@ class TranslationWriter
             'descriptionLong',
             'metaTitle',
             'keywords',
+            'shippingTime',
         ];
 
         $variantWhiteList = [
             'additionalText',
             'packUnit',
+            'shippingTime',
         ];
 
         $whiteList = \array_merge($whiteList, $variantWhiteList);

--- a/Components/SwagImportExport/DbAdapters/ArticlesDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/ArticlesDbAdapter.php
@@ -402,6 +402,7 @@ class ArticlesDbAdapter implements DataDbAdapter
             $result[$index]['descriptionLong'] = $data['txtlangbeschreibung'];
             $result[$index]['metaTitle'] = $data['metaTitle'];
             $result[$index]['keywords'] = $data['txtkeywords'];
+            $result[$index]['shippingtime'] = $data['txtshippingtime'];
         }
 
         return $result;
@@ -817,6 +818,7 @@ class ArticlesDbAdapter implements DataDbAdapter
             'translation.description_long as descriptionLong',
             'translation.additionalText as additionalText',
             'translation.packUnit as packUnit',
+            'translation.shippingtime as shippingTime',
         ];
 
         $attributes = $this->getTranslatableAttributes();
@@ -1294,6 +1296,7 @@ class ArticlesDbAdapter implements DataDbAdapter
             'txtzusatztxt' => 'additionalText',
             'txtshortdescription' => 'description',
             'txtlangbeschreibung' => 'descriptionLong',
+            'txtshippingtime' => 'shippingTime',
         ];
 
         $attributes = $this->getTranslatableAttributes();

--- a/Components/SwagImportExport/Transformers/FlattenTransformer.php
+++ b/Components/SwagImportExport/Transformers/FlattenTransformer.php
@@ -1280,6 +1280,7 @@ class FlattenTransformer implements DataTransformerAdapter, ComposerInterface
                 'descriptionLong',
                 'additionalText',
                 'packUnit',
+                'shippingTime',
             ];
 
             $attributes = $this->getAttributeColumns();


### PR DESCRIPTION
this field shippingTime is by shopware default translatable.
![Bildschirmfoto 2021-03-25 um 21 44 32](https://user-images.githubusercontent.com/907458/112541246-75cd8e00-8db3-11eb-9321-c9422da9882f.png)
but currently it is not possible to export or import shippingTimes translations.

With this pull request, the "shippng time" can also be used from the list of translatable fields.
![Bildschirmfoto 2021-03-25 um 21 48 28](https://user-images.githubusercontent.com/907458/112541903-3a7f8f00-8db4-11eb-9a67-99a931b9fd5e.png)

Export and Reimport from Shipping Time translations is possible.