### PR TITLE
add clearedDate to order main data export

### DIFF
--- a/Components/SwagImportExport/DbAdapters/MainOrdersDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/MainOrdersDbAdapter.php
@@ -212,6 +212,7 @@ class MainOrdersDbAdapter implements DataDbAdapter
             'orders.currencyFactor',
             'orders.transactionId',
             'orders.trackingCode',
+            "DATE_FORMAT(orders.clearedDate, '%Y-%m-%d %H:%i:%s') as clearedDate",
             "DATE_FORMAT(orders.orderTime, '%Y-%m-%d %H:%i:%s') as orderTime",
             'customer.email',
             'billing.number as customerNumber',


### PR DESCRIPTION
The field clearedDate was missing in the export profile "default_order_main_data". This pr adds the field.
![image](https://user-images.githubusercontent.com/8171870/155088117-254b25b4-8ae4-4c9c-9b48-21f2a345d1ed.png)
