### PR TITLE
fix: Bracket for correct error message

### DIFF
--- a/Components/SwagImportExport/DbAdapters/ArticlesImagesDbAdapter.php
+++ b/Components/SwagImportExport/DbAdapters/ArticlesImagesDbAdapter.php
@@ -674,7 +674,7 @@ class ArticlesImagesDbAdapter implements DataDbAdapter
         if (!$put_handle) {
             $message = SnippetsHelper::getNamespace()
                 ->get('adapters/articlesImages/could_open_dir_file', 'Could not open %s/%s for writing');
-            throw new AdapterException(\sprintf($message), $destPath, $filename);
+            throw new AdapterException(\sprintf($message, $destPath, $filename));
         }
 
         //replace empty spaces


### PR DESCRIPTION
:upside_down_face: The second argument of the `Enlight_Exception` should be the code and the third should be the instance of another `Exception`.