### PR TITLE
PT-13090 - Added github workflow

### DIFF
--- a/.github/workflows/call-plugin-workflow.yml
+++ b/.github/workflows/call-plugin-workflow.yml
@@ -1,0 +1,17 @@
+name: Run plugin workflow
+
+on:
+    workflow_dispatch:
+    push:
+
+jobs:
+    call-plugin-workflow:
+        strategy:
+            matrix:
+                php-version: [ '7.4', '8.2' ]
+                shopware-version: [ '5.7' ]
+        uses: shopware5/docker-images-testing/.github/workflows/plugin-workflow.yml@main
+        with:
+            plugin-name: SwagImportExport
+            php-version: ${{ matrix.php-version }}
+            shopware-version: ${{ matrix.shopware-version }}

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ install-test-environment: ## Installs the plugin test environment
 
 run-tests: ## Execute the php unit tests... (You can use the filter parameter "make run-tests filter=yourFilterPhrase")
 ifeq ($(filter), "default")
-	SHOPWARE_ENV=$(envname) ./../../../vendor/phpunit/phpunit/phpunit --verbose
+	SHOPWARE_ENV=$(envname) ./../../../vendor/phpunit/phpunit/phpunit --verbose --stderr
 else
-	SHOPWARE_ENV=$(envname) ./../../../vendor/phpunit/phpunit/phpunit --verbose --filter $(filter)
+	SHOPWARE_ENV=$(envname) ./../../../vendor/phpunit/phpunit/phpunit --verbose --stderr --filter $(filter)
 endif
 
 CS_FIXER_RUN=


### PR DESCRIPTION
Requires https://github.com/shopware5/docker-images-testing/pulls to be merged in order to work. 

There is now a unified [reusable](https://docs.github.com/en/actions/using-workflows/reusing-workflows) workflow for all the plugins