### PR TITLE
fix export command wrong file path use project dir instead of root dir

### DIFF
--- a/Resources/services/commands.xml
+++ b/Resources/services/commands.xml
@@ -21,7 +21,7 @@
             <argument type="service" id="SwagImportExport\Components\Factories\ProfileFactory"/>
             <argument type="service" id="models"/>
             <argument type="service" id="SwagImportExport\Components\Session\SessionService"/>
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
             <argument type="service" id="SwagImportExport\Components\Logger\Logger"/>
             <argument type="service" id="SwagImportExport\Components\Service\ExportService"/>
             <argument type="service" id="config"/>

--- a/Tests/Helper/CommandTestCaseTrait.php
+++ b/Tests/Helper/CommandTestCaseTrait.php
@@ -61,6 +61,6 @@ trait CommandTestCaseTrait
 
     private function getFilePath(string $fileName): string
     {
-        return Shopware()->DocPath() . $fileName;
+        return sprintf('%s/%s', $this->getContainer()->getParameter('kernel.project_dir'), $fileName);
     }
 }


### PR DESCRIPTION
Currently `%kernel.root_dir%` is used as path for exporting files with the command `sw:importexport:export` which causes saving the files to the wrong path: `vendor/shopware/shopware`. With this change `%kernel.project_dir%` is used as export path.

Tested Environment:

-  PHP 8.0.30
- DB: 10.3.39-MariaDB
- Shopware with Composer: 5.7.16